### PR TITLE
Errors in Make commands involving eval

### DIFF
--- a/rebar3_riak_core_lite_Makefile.tpl
+++ b/rebar3_riak_core_lite_Makefile.tpl
@@ -70,16 +70,16 @@ devrel-start:
 	for d in $(BASEDIR)/_build/dev*; do $$d/rel/{{ name }}/bin/$(APPNAME) start; done
 
 devrel-join:
-	for d in $(BASEDIR)/_build/dev{2,3}; do $$d/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core:join("{{ name }}1@127.0.0.1")'; done
+	for d in $(BASEDIR)/_build/dev{2,3}; do $$d/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core:join("{{ name }}1@127.0.0.1").'; done
 
 devrel-cluster-plan:
-	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_claimant:plan()'
+	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_claimant:plan().'
 
 devrel-cluster-commit:
-	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_claimant:commit()'
+	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_claimant:commit().'
 
 devrel-status:
-	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_console:member_status([])'
+	$(BASEDIR)/_build/dev1/rel/{{ name }}/bin/$(APPNAME) eval 'riak_core_console:member_status([]).'
 
 devrel-ping:
 	for d in $(BASEDIR)/_build/dev*; do $$d/rel/{{ name }}/bin/$(APPNAME) ping; true; done


### PR DESCRIPTION
I was trying the Getting Started [example](https://riak-core-lite.github.io/blog/pages/getting-started/) and I encountered this error when I executed `make devrel-status`:
```
ricor/_build/dev1/rel/ricor/bin/ricor eval 'riak_core_console:member_status([])'
escript: exception error: no match of right hand side value 
                 {error,{1,erl_parse,["syntax error before: ",[]]}}
  in function  erl_eval:expr/5 (erl_eval.erl, line 453)
  in call from erl_eval:exprs/5 (erl_eval.erl, line 126)
  in call from escript:eval_exprs/5 (escript.erl, line 872)
  in call from erl_eval:local_func/6 (erl_eval.erl, line 567)
  in call from escript:interpret/4 (escript.erl, line 788)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 
make: *** [Makefile:82: devrel-status] Error 127
```
I was using Erlang/OTP 22 on Ubuntu 20.04. I tried OTP 23 on the same machine and I got this error:
```
ricor/_build/dev1/rel/ricor/bin/ricor eval 'riak_core_console:member_status([])'
{error, "Incomplete form (missing .<cr>)??"}%  
```
It was likely due to the missing period in the eval commands in the makefile. When I added the period and tried again (using OTP 22), I got the status of the ring in the terminal where I entered the command. I tried the same fix in another rebar3 app that uses OTP 23 and I got the status of the ring in the terminal of that node.

I'm not sure why the period was necessary, because the following worked without any errors:
```
erl -noshell -eval 'c:ls()' -eval 'init:stop()'
```
But I think these changes fix the errors with the makefile. 